### PR TITLE
Add LinkedIn auto-connect Chrome extension

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -63,12 +63,15 @@
       if (!isVisible(btn) || btn.disabled) return false;
 
       const t = normalize(btn.textContent).toLowerCase();
-      if (!t.includes('connect')) return false;
+
+      const isConnectIntent = t.includes('connect') || t.includes('invite');
+      if (!isConnectIntent) return false;
 
       if (
         t.includes('pending') ||
         t.includes('requested') ||
         t.includes('invite sent') ||
+        t.includes('invitation sent') ||
         t.includes('following') ||
         t.includes('follow')
       ) {
@@ -182,6 +185,10 @@
       return { status: 'already_running', message: 'Auto-connect is already running on this page.' };
     }
 
+    if (!/linkedin\.com$/i.test(location.hostname)) {
+      return { status: 'error', message: 'This only runs on linkedin.com pages.' };
+    }
+
     window.__LI_AUTO_CONNECT_RUNNING__ = true;
     window.__LI_AUTO_CONNECT_STOP__ = false;
 
@@ -200,6 +207,7 @@
         let buttons = getConnectButtons().filter((b) => !seen.has(b));
 
         if (!buttons.length) {
+          log('No new connect buttons visible yet, scrolling to look for more…');
           if (!CONFIG.autoScroll) break;
 
           const moved = await autoScrollOnce();
@@ -217,6 +225,8 @@
           }
           continue;
         }
+
+        log(`Found ${buttons.length} connectable button(s) on screen.`);
 
         const btn = buttons[0];
         seen.add(btn);

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,309 @@
+(() => {
+  'use strict';
+
+  const CONFIG = {
+    delayBetweenInvitesMs: 1600,
+    popupWaitTimeoutMs: 6500,
+    autoScroll: true,
+    scrollPauseMs: 900,
+    maxScrollAttemptsWithoutNew: 12,
+    maxToSend: 100
+  };
+
+  const log = (...a) => console.log('%c[LI Auto-Connect]', 'color:#0b69ff;font-weight:600', ...a);
+  const warn = (...a) => console.warn('%c[LI Auto-Connect]', 'color:#ff7a00;font-weight:600', ...a);
+  const err = (...a) => console.error('%c[LI Auto-Connect]', 'color:#ff2d55;font-weight:700', ...a);
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const nowISO = () => new Date().toISOString();
+  const normalize = (s) => (s || '').replace(/\s+/g, ' ').trim();
+
+  const isVisible = (el) => {
+    if (!el) return false;
+    const cs = getComputedStyle(el);
+    if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+
+  function nameFromAria(aria) {
+    if (!aria) return '';
+    const patterns = [
+      /invite\s+(.+?)\s+to\s+connect/i,
+      /connect with\s+(.+?)$/i,
+      /connect\s+(.+?)$/i
+    ];
+    for (const re of patterns) {
+      const m = re.exec(aria);
+      if (m && m[1]) return normalize(m[1]);
+    }
+    return '';
+  }
+
+  function findProfileInfo(btn) {
+    const aria = btn.getAttribute('aria-label') || '';
+    let name = nameFromAria(aria);
+    let profileUrl = '';
+
+    const container =
+      btn.closest(
+        'li, .entity-result, .reusable-search__result-container, .artdeco-card, .search-result__wrapper, .scaffold-finite-scroll__content'
+      ) || document;
+    const anchors = Array.from(container.querySelectorAll('a[href*="/in/"]'));
+    if (anchors.length) {
+      const a = anchors[0];
+      profileUrl = a.href;
+      if (!name) name = normalize(a.textContent);
+    }
+    return { name, profileUrl, aria };
+  }
+
+  function getConnectButtons() {
+    const all = Array.from(document.querySelectorAll('button'));
+    return all.filter((btn) => {
+      if (!isVisible(btn) || btn.disabled) return false;
+
+      const t = normalize(btn.textContent).toLowerCase();
+      if (!t.includes('connect')) return false;
+
+      if (
+        t.includes('pending') ||
+        t.includes('requested') ||
+        t.includes('invite sent') ||
+        t.includes('following') ||
+        t.includes('follow')
+      ) {
+        return false;
+      }
+
+      const aria = (btn.getAttribute('aria-label') || '').toLowerCase();
+      if (aria && !(aria.includes('connect') || aria.includes('invite'))) return false;
+
+      return true;
+    });
+  }
+
+  async function clickSendWithoutNote(timeoutMs = CONFIG.popupWaitTimeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+
+    const tryFindAndClick = () => {
+      const scopes = document.querySelectorAll('[role="dialog"], .artdeco-modal, .ember-view[role="dialog"]');
+      const roots = scopes.length ? Array.from(scopes) : [document];
+
+      for (const root of roots) {
+        const btns = Array.from(root.querySelectorAll('button')).filter(isVisible);
+
+        let target = btns.find((b) => /send without a note/i.test(normalize(b.textContent)));
+        if (target) {
+          target.click();
+          return true;
+        }
+
+        const modalText = normalize(root.textContent).toLowerCase();
+        if (modalText.includes('add a note') || modalText.includes('invite') || modalText.includes('connect')) {
+          target = btns.find((b) => /^(send|send now)$/i.test(normalize(b.textContent)));
+          if (target) {
+            target.click();
+            return true;
+          }
+        }
+
+        target = btns.find((b) => /send/i.test(b.getAttribute('aria-label') || ''));
+        if (target) {
+          target.click();
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (tryFindAndClick()) return true;
+
+    return await new Promise((resolve) => {
+      let resolved = false;
+      const observer = new MutationObserver(() => {
+        if (resolved) return;
+        if (tryFindAndClick()) {
+          resolved = true;
+          observer.disconnect();
+          resolve(true);
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      const poll = setInterval(() => {
+        if (resolved) return;
+        if (Date.now() > deadline) {
+          resolved = true;
+          observer.disconnect();
+          clearInterval(poll);
+          resolve(false);
+        } else if (tryFindAndClick()) {
+          resolved = true;
+          observer.disconnect();
+          clearInterval(poll);
+          resolve(true);
+        }
+      }, 200);
+    });
+  }
+
+  async function autoScrollOnce() {
+    const before = window.scrollY;
+    window.scrollBy(0, Math.max(window.innerHeight * 0.9, 500));
+    await sleep(CONFIG.scrollPauseMs);
+    return window.scrollY !== before;
+  }
+
+  function csvEscape(value) {
+    const s = (value ?? '').toString().replace(/"/g, '""');
+    return `"${s}"`;
+  }
+
+  function downloadCSV(rows, filename) {
+    const header = ['timestamp', 'name', 'profileUrl', 'ariaLabel', 'buttonId', 'pageUrl', 'result'];
+    const lines = [header.map(csvEscape).join(',')];
+    for (const r of rows) {
+      const arr = [r.timestamp, r.name, r.profileUrl, r.ariaLabel, r.buttonId, r.pageUrl, r.result];
+      lines.push(arr.map(csvEscape).join(','));
+    }
+    const blob = new Blob(['\uFEFF' + lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  async function runAutoConnect() {
+    if (window.__LI_AUTO_CONNECT_RUNNING__) {
+      return { status: 'already_running', message: 'Auto-connect is already running on this page.' };
+    }
+
+    window.__LI_AUTO_CONNECT_RUNNING__ = true;
+    window.__LI_AUTO_CONNECT_STOP__ = false;
+
+    const pageUrl = location.href;
+    const logEntries = [];
+    window.__LI_AUTO_CONNECT_LOG__ = logEntries;
+
+    log(`Starting… Limit = ${CONFIG.maxToSend}. To stop: window.__LI_AUTO_CONNECT_STOP__ = true`);
+
+    try {
+      const seen = new WeakSet();
+      let sent = 0;
+      let noNewButtonsScrolls = 0;
+
+      while (!window.__LI_AUTO_CONNECT_STOP__) {
+        let buttons = getConnectButtons().filter((b) => !seen.has(b));
+
+        if (!buttons.length) {
+          if (!CONFIG.autoScroll) break;
+
+          const moved = await autoScrollOnce();
+          await sleep(150);
+
+          const afterButtons = getConnectButtons().filter((b) => !seen.has(b));
+          if (!moved || afterButtons.length === 0) {
+            noNewButtonsScrolls++;
+            if (noNewButtonsScrolls >= CONFIG.maxScrollAttemptsWithoutNew) {
+              log('No new connectable buttons after multiple scrolls. Stopping.');
+              break;
+            }
+          } else {
+            noNewButtonsScrolls = 0;
+          }
+          continue;
+        }
+
+        const btn = buttons[0];
+        seen.add(btn);
+
+        const btnId = btn.id || '';
+        const { name, profileUrl, aria } = findProfileInfo(btn);
+
+        btn.scrollIntoView({ behavior: 'auto', block: 'center' });
+        await sleep(220);
+        log(`Clicking: ${normalize(aria || btn.textContent)}${name ? ` (→ ${name})` : ''}`);
+        btn.click();
+
+        await sleep(250);
+        let wasSent = await clickSendWithoutNote(CONFIG.popupWaitTimeoutMs);
+
+        if (!wasSent) {
+          await sleep(650);
+          const stateText = normalize((btn && btn.textContent) || '');
+          if (!btn || !btn.isConnected || /pending|invite sent|requested/i.test(stateText.toLowerCase())) {
+            wasSent = true;
+          }
+        }
+
+        logEntries.push({
+          timestamp: nowISO(),
+          name,
+          profileUrl,
+          ariaLabel: aria || '',
+          buttonId: btnId,
+          pageUrl,
+          result: wasSent ? 'sent' : 'skipped_no_send_button'
+        });
+
+        if (wasSent) {
+          sent++;
+          log(`✅ Invitation logged${name ? ` to ${name}` : ''}. Total sent: ${sent}`);
+        } else {
+          warn('No send confirmation detected; logged as skipped.');
+        }
+
+        if (sent >= CONFIG.maxToSend) {
+          log(`Reached maxToSend (${CONFIG.maxToSend}). Stopping.`);
+          break;
+        }
+
+        if (window.__LI_AUTO_CONNECT_STOP__) break;
+        await sleep(CONFIG.delayBetweenInvitesMs);
+      }
+
+      const successful = logEntries.filter((r) => r.result === 'sent');
+      const dt = new Date();
+      const pad = (n) => String(n).padStart(2, '0');
+      const filename = `linkedin_autoconnect_log_${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())}_${pad(
+        dt.getHours()
+      )}-${pad(dt.getMinutes())}-${pad(dt.getSeconds())}.csv`;
+      downloadCSV(successful, filename);
+
+      const summary = `Finished. Invitations sent: ${sent}. CSV downloaded as ${filename}. (Logged: ${logEntries.length})`;
+      log(summary);
+
+      return { status: 'completed', sent, filename, totalLogged: logEntries.length, summary };
+    } catch (error) {
+      err('Error while running auto-connect', error);
+      return { status: 'error', message: error?.message || 'Unknown error' };
+    } finally {
+      window.__LI_AUTO_CONNECT_RUNNING__ = false;
+    }
+  }
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message?.type === 'RUN_AUTO_CONNECT') {
+      if (window.__LI_AUTO_CONNECT_RUNNING__) {
+        sendResponse({ ok: true, result: { status: 'already_running' } });
+        return false;
+      }
+
+      sendResponse({ ok: true, result: { status: 'started' } });
+
+      runAutoConnect()
+        .then((result) => {
+          chrome.runtime.sendMessage({ type: 'AUTO_CONNECT_RESULT', result });
+        })
+        .catch((error) => {
+          chrome.runtime.sendMessage({ type: 'AUTO_CONNECT_RESULT', error: error.message });
+        });
+      return false;
+    }
+    return false;
+  });
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "LinkedIn Auto-Connect Easy Button",
+  "description": "One-click auto-connect invitations on LinkedIn with CSV logging.",
+  "version": "1.0.0",
+  "permissions": ["tabs"],
+  "host_permissions": [
+    "https://www.linkedin.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "LinkedIn Auto-Connect"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.linkedin.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LinkedIn Auto-Connect</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 12px;
+      min-width: 260px;
+      color: #1b1b1b;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 16px;
+      color: #0a66c2;
+    }
+    p {
+      margin: 4px 0 10px;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+    button {
+      background-color: #0a66c2;
+      color: white;
+      border: none;
+      padding: 10px 14px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+      width: 100%;
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+    #status {
+      margin-top: 10px;
+      font-size: 12px;
+      color: #4b4b4b;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>LinkedIn Auto-Connect</h1>
+  <p>Open a LinkedIn search results page and click the button to send connection requests automatically.</p>
+  <button id="start">Run Auto-Connect</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -50,6 +50,12 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
+      if (!/^https?:\/\/([a-zA-Z0-9-]+\.)*linkedin\.com\//.test(tab.url || '')) {
+        setLoading(false);
+        setStatus('Please open a linkedin.com page with Connect buttons and try again.');
+        return;
+      }
+
       chrome.tabs.sendMessage(tab.id, { type: 'RUN_AUTO_CONNECT' }, (response) => {
         if (chrome.runtime.lastError) {
           setLoading(false);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,74 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const startButton = document.getElementById('start');
+  const statusEl = document.getElementById('status');
+
+  const setStatus = (text) => {
+    statusEl.textContent = text;
+  };
+
+  const setLoading = (isLoading) => {
+    startButton.disabled = isLoading;
+    startButton.textContent = isLoading ? 'Running…' : 'Run Auto-Connect';
+  };
+
+  const updateFromResult = (result) => {
+    if (!result) {
+      setStatus('No response from the page. Make sure you are on LinkedIn.');
+      return;
+    }
+
+    if (result.status === 'already_running') {
+      setStatus('Auto-connect is already running on this page.');
+    } else if (result.status === 'completed') {
+      const summary = `Invitations sent: ${result.sent}. Log file: ${result.filename}. Logged entries: ${result.totalLogged}.`;
+      setStatus(`Done! ${summary}`);
+    } else if (result.status === 'error') {
+      setStatus(`Error: ${result.message}`);
+    } else {
+      setStatus('Started! Check the page console for live progress.');
+    }
+  };
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message?.type === 'AUTO_CONNECT_RESULT') {
+      setLoading(false);
+      updateFromResult(message.result || { status: 'error', message: message.error });
+    }
+  });
+
+  startButton.addEventListener('click', () => {
+    setLoading(true);
+    setStatus('Checking the active tab…');
+
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const [tab] = tabs || [];
+      if (!tab?.id) {
+        setLoading(false);
+        setStatus('No active tab found.');
+        return;
+      }
+
+      chrome.tabs.sendMessage(tab.id, { type: 'RUN_AUTO_CONNECT' }, (response) => {
+        if (chrome.runtime.lastError) {
+          setLoading(false);
+          setStatus('Could not inject into this page. Please open LinkedIn and try again.');
+          return;
+        }
+
+        setStatus('Starting… Watch the page console for updates.');
+
+        if (response?.result) {
+          updateFromResult(response.result);
+          if (response.result.status !== 'started') {
+            setLoading(false);
+          }
+        } else {
+          setLoading(false);
+          setStatus('No response from the page. Make sure you are on LinkedIn.');
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Chrome extension scaffold with manifest, popup UI, and messaging hooks
- convert the LinkedIn auto-connect snippet into a content script triggered by the popup button
- export run results via runtime messages and CSV download

## Testing
- not run (extension code only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e62662a2c832b9cc78f4539eddad3)